### PR TITLE
fix: Update `goheader` linter setting to support 2024 and onwards

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,9 @@ linters-settings:
     values:
       const:
         COMPANY: Cofide Limited
+      regexp:
+        VALID_YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
     template: |
-      Copyright {{ MOD-YEAR }} {{ COMPANY }}.
+      Copyright {{ VALID_YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,6 @@ linters-settings:
       regexp:
         VALID_YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
-    template: |
+    template: |-
       Copyright {{ VALID_YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Summary
- This PR adds a small fix to the `goheader` linter setting in `.golangci.yaml` to allow all years from 2024 and onwards to be valid, resolving the following error:
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.63.1-linux-amd64/golangci-lint run  --timeout=5m] in [/home/runner/work/cofidectl-debug-container/cofidectl-debug-container] ...
  Error: cmd/main.go:1:14: Expected:2025, Actual: 2024 Cofide Limited. (goheader)
  // Copyright 2024 Cofide Limited.
               ^
  
  Error: issues found
  Ran golangci-lint in 20200ms
``` 
