### PR TITLE
fix: Add `types: [published]` to the release trigger 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   release:
+    types:
+      - published
     
 jobs:
   build-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: docker-image
+name: release
 on:
   push:
     branches:
@@ -8,8 +8,8 @@ on:
       - published
     
 jobs:
-  build-test:
-    name: build
+  build-release:
+    name: build-release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
### Summary
- This PR adds `types: [published]` to the release trigger on the GitHub Actions workflow defined in `.github/workflows/docker.yml`.
- This resolves the issue where multiple, duplicated workflows were being triggered after publishing a release.
![Screenshot 2025-01-27 at 15 26 57](https://github.com/user-attachments/assets/9d8020c9-2e26-4e3e-bb2f-82d0740cdaf1)

- The GitHub Actions workflow is also renamed from `docker-image` to `release`.